### PR TITLE
added gentoo and funtoo operating systems

### DIFF
--- a/data/oses/Makefile.am
+++ b/data/oses/Makefile.am
@@ -22,6 +22,8 @@ database_in_files = 	\
 	suse.xml.in     \
 	ubuntu.xml.in   \
 	windows.xml.in  \
+	gentoo.xml.in  \
+	funtoo.xml.in  \
 	$(NULL)
 
 database_DATA = $(database_in_files:.xml.in=.xml)

--- a/data/oses/funtoo.xml.in
+++ b/data/oses/funtoo.xml.in
@@ -1,0 +1,9 @@
+<libosinfo version="0.0.1">
+  <os id="https://funtoo.org/">
+    <short-id>Funtoo</short-id>
+    <_name>Funtoo</_name>
+    <_vendor>Funtoo Project</_vendor>
+    <family>linux</family>
+    <distro>linux</distro>
+  </os>
+</libosinfo>

--- a/data/oses/gentoo.xml.in
+++ b/data/oses/gentoo.xml.in
@@ -1,0 +1,9 @@
+<libosinfo version="0.0.1">
+  <os id="https://gentoo.org/">
+    <short-id>Gentoo</short-id>
+    <_name>Gentoo</_name>
+    <_vendor>Gentoo Project</_vendor>
+    <family>linux</family>
+    <distro>linux</distro>
+  </os>
+</libosinfo>


### PR DESCRIPTION
this is done largely to satisfy the ability to competently identify these operating systems at build time during KVM/qemu provisioning by tools like virt-install.  
